### PR TITLE
ci: pre-releases automaticos en staging y releases con tag v*

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+# Tag v* (ej: v0.2.0) -> build prod -> Release estable con zip.
+# El tag lo crea la persona a mano: git tag v0.2.0 && git push origin v0.2.0
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: lefarma.frontend
+
+      - name: Build (multiappcli build)
+        run: pwsh ./multiappcli.ps1 build
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: publish/lefarma-prod.zip

--- a/.github/workflows/staging-prerelease.yml
+++ b/.github/workflows/staging-prerelease.yml
@@ -1,0 +1,40 @@
+# Push/PR merge a staging -> build qa -> pre-release con zip.
+# El tag qa-<run_number> lo genera este workflow; nadie lo crea a mano.
+name: Staging pre-release
+
+on:
+  push:
+    branches: [staging]
+
+jobs:
+  build-and-prerelease:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: lefarma.frontend
+
+      - name: Build (multiappcli build:qa)
+        run: pwsh ./multiappcli.ps1 build:qa
+
+      - name: Create pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: qa-${{ github.run_number }}
+          name: qa-${{ github.run_number }}
+          prerelease: true
+          target_commitish: ${{ github.sha }}
+          files: publish/lefarma-qa.zip

--- a/deploy/lefarma-autodeploy.ps1
+++ b/deploy/lefarma-autodeploy.ps1
@@ -1,0 +1,75 @@
+# lefarma-autodeploy.ps1 — vive en el servidor 192.168.4.2 (NO en el repo si no quieres).
+# Scheduled Task cada 5 min: busca Releases nuevos en GitHub y publica.
+#   pre-release (qa-*)  -> carpeta staging
+#   release     (v*)    -> carpeta produccion
+# Sin logica de versiones: tag distinto al ultimo desplegado -> desplegar.
+
+$ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12  # PS 5.1
+
+# ============ CONFIG (llenar) ============
+$Owner     = "GrupoLefarma2025"
+$Repo      = "01-lefarma-project"
+$BaseDir   = "C:\LefarmaDeploy"
+$TokenFile = "$BaseDir\.token"        # contiene el PAT; solo Administradores lo leen
+$Targets = @{
+    qa   = "D:\Desarrollo-pruebas-base"   # sitio IIS "Desarrollo-demos", pool Desarrollo-base-lefarma, :5073
+    prod = ""    # carpeta produccion de Lefarma en este servidor
+}
+# =========================================
+
+$StateDir = "$BaseDir\state"
+$WorkDir  = "$BaseDir\work"
+$LogFile  = "$BaseDir\autodeploy.log"
+
+function Log($msg) {
+    Add-Content -LiteralPath $LogFile -Value ("{0} | {1}" -f (Get-Date -Format "yyyy-MM-dd HH:mm:ss"), $msg)
+}
+
+function Get-LatestRelease([bool]$Pre) {
+    $list = Invoke-RestMethod -Uri "https://api.github.com/repos/$Owner/$Repo/releases?per_page=20" `
+            -Headers @{ Authorization = "Bearer $token"; Accept = "application/vnd.github+json" }
+    $list | Where-Object { $_.prerelease -eq $Pre -and -not $_.draft } | Select-Object -First 1
+}
+
+function Deploy($rel, $target, $stateFile) {
+    $last = if (Test-Path $stateFile) { (Get-Content $stateFile -Raw).Trim() } else { "" }
+    if ($rel.tag_name -eq $last) { return }
+
+    $asset = $rel.assets | Select-Object -First 1
+    if (-not $asset) { Log "WARN $($rel.tag_name) sin zip, saltando"; return }
+
+    Log "NUEVO $($rel.tag_name) -> $target"
+    $zip = Join-Path $WorkDir $asset.name
+    Invoke-WebRequest -Uri $asset.browser_download_url -Headers @{ Authorization = "Bearer $token" } -OutFile $zip
+
+    $tmp = Join-Path $WorkDir ("x-" + [guid]::NewGuid().ToString("N"))
+    Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force
+
+    # /E sobreescribe sin borrar archivos extra del destino; /XF protege configs por doble seguro
+    # ponytail: quedan DLLs huerfanos de versiones previas; si estorba, /MIR + /XF de estas mismas exclusiones
+    robocopy $tmp $target /E /XF appsettings*.json web.config /R:1 /W:1 /NFL /NDL /NJH /NJS | Out-Null
+    if ($LASTEXITCODE -ge 8) { throw "robocopy fallo ($LASTEXITCODE)" }
+
+    $wc = Join-Path $target "web.config"
+    if (Test-Path $wc) { (Get-Item $wc).LastWriteTime = Get-Date }  # fuerza recycle de IIS
+
+    Set-Content -LiteralPath $stateFile -Value $rel.tag_name
+    Remove-Item $zip, $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    Log "OK $($rel.tag_name) desplegado"
+}
+
+# ---- main ----
+foreach ($d in @($StateDir, $WorkDir)) { New-Item -ItemType Directory -Path $d -Force | Out-Null }
+if (-not (Test-Path $TokenFile)) { Log "ERROR: falta $TokenFile"; exit 1 }
+$token = (Get-Content $TokenFile -Raw).Trim()
+
+try {
+    $qa = Get-LatestRelease $true
+    if ($qa -and $Targets.qa) { Deploy $qa $Targets.qa "$StateDir\last-qa.txt" }
+} catch { Log "ERROR qa: $_" }
+
+try {
+    $prod = Get-LatestRelease $false
+    if ($prod -and $Targets.prod) { Deploy $prod $Targets.prod "$StateDir\last-prod.txt" }
+} catch { Log "ERROR prod: $_" }

--- a/deploy/lefarma-autodeploy.ps1
+++ b/deploy/lefarma-autodeploy.ps1
@@ -46,13 +46,19 @@ function Deploy($rel, $target, $stateFile) {
     $tmp = Join-Path $WorkDir ("x-" + [guid]::NewGuid().ToString("N"))
     Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force
 
+    # app_offline.htm: ANCM apaga SOLO esta app y suelta los locks de DLLs (sin iisreset, sin tocar otras)
+    $offline = Join-Path $target "app_offline.htm"
+    Set-Content -LiteralPath $offline "<html><body>deploy en curso</body></html>"
+    Start-Sleep -Seconds 3
+
     # /E sobreescribe sin borrar archivos extra del destino; /XF protege configs por doble seguro
     # ponytail: quedan DLLs huerfanos de versiones previas; si estorba, /MIR + /XF de estas mismas exclusiones
-    robocopy $tmp $target /E /XF appsettings*.json web.config /R:1 /W:1 /NFL /NDL /NJH /NJS | Out-Null
+    robocopy $tmp $target /E /XF appsettings*.json web.config app_offline.htm /R:1 /W:1 /NFL /NDL /NJH /NJS | Out-Null
     if ($LASTEXITCODE -ge 8) { throw "robocopy fallo ($LASTEXITCODE)" }
 
+    Remove-Item -LiteralPath $offline -Force -ErrorAction SilentlyContinue  # la app levanta al siguiente request
     $wc = Join-Path $target "web.config"
-    if (Test-Path $wc) { (Get-Item $wc).LastWriteTime = Get-Date }  # fuerza recycle de IIS
+    if (Test-Path $wc) { (Get-Item $wc).LastWriteTime = Get-Date }  # recycle extra por si acaso
 
     Set-Content -LiteralPath $stateFile -Value $rel.tag_name
     Remove-Item $zip, $tmp -Recurse -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
Que agrega:
- workflow staging-prerelease: push/merge a staging -> build:qa -> pre-release qa-<run_number> con lefarma-qa.zip
- workflow release: tag v* -> build prod -> Release estable con lefarma-prod.zip
- deploy/lefarma-autodeploy.ps1: script para el servidor 192.168.4.2 (Scheduled Task 5 min) que descarga releases nuevos y publica sin tocar configs

Test: al mergear este PR se dispara el primer pre-release solo.